### PR TITLE
Fix stack overflow in "port" functions

### DIFF
--- a/src/port.c
+++ b/src/port.c
@@ -38,11 +38,11 @@ static void gram_schmidt (double *res, double **span,
 int port_sample(double *res, double *madj,	double *Q, unsigned int p,
 	unsigned int N) {
 
-	double mort[p * p];
-
 	if (res == NULL || madj == NULL || Q == NULL) {
 		return PORT_ENULL;
 	}
+
+    double *mort = malloc(p * p * sizeof(double));
 
 	for (int n = 0; n < N; n++) {
 		/* Partial orthogonalization of the initial Q factors */
@@ -50,6 +50,8 @@ int port_sample(double *res, double *madj,	double *Q, unsigned int p,
 		/* Crossproduct t(Q) * Q of the resulting factors */
 		crossproduct(res + n*p*p, mort, madj, p);
 	}
+
+    free(mort);
 
 	return PORT_OK;
 }

--- a/src/port.c
+++ b/src/port.c
@@ -42,7 +42,7 @@ int port_sample(double *res, double *madj,	double *Q, unsigned int p,
 		return PORT_ENULL;
 	}
 
-    double *mort = malloc(p * p * sizeof(double));
+	double *mort = malloc(p * p * sizeof(double));
 
 	for (int n = 0; n < N; n++) {
 		/* Partial orthogonalization of the initial Q factors */
@@ -51,14 +51,15 @@ int port_sample(double *res, double *madj,	double *Q, unsigned int p,
 		crossproduct(res + n*p*p, mort, madj, p);
 	}
 
-    free(mort);
+	free(mort);
 
 	return PORT_OK;
 }
 
 static void port(double *res, double *madj, double *Q, unsigned int p) {
 
-	double *span_sel[p], ort_base[p * p];
+	double *span_sel[p];
+	double *ort_base = malloc(p * p * sizeof(double));
 	unsigned int n_span = 0, jp = 0;
 
 	memcpy(res, Q, sizeof(double) * p * p);
@@ -82,6 +83,8 @@ static void port(double *res, double *madj, double *Q, unsigned int p) {
 		/* the last vector of the orthonormalized span is the new j-th column */
 		memcpy(res + jp, ort_base + (n_span - 1)*p, sizeof(double) * p);
 	}
+
+	free(ort_base);
 }
 
 /*


### PR DESCRIPTION
Using heap allocation instead of the stack in `port` and `port_sample` functions of `port.c` to avoid stack overflow for big graphs.

Example of code that triggers this error (that may depends on the OS configuration):
```R
library(gmat)
nb.nodes=750
g <- rgraph(p = nb.nodes, d = 0.1, dag = FALSE)
res <- gmat::port_chol(N=1, ug = g)
```